### PR TITLE
Fix: `fastn build` failure in CI

### DIFF
--- a/FASTN.ftd
+++ b/FASTN.ftd
@@ -11,8 +11,8 @@ download-base-url: https://raw.githubusercontent.com/fastn-stack/fastn-js/main
 
 # Home: /
 
-# Typo Exporter: /typo/
+# Typo Exporter: /typo-exporter/
   document: typo-exporter.ftd
 
-# CS Exporter: /cs/
+# CS Exporter: /json-exporter/
   document: json-exporter.ftd


### PR DESCRIPTION
Renaming the urls to match the filename somehow makes `fastn build` work. The last CI run was done about an year ago so it's very hard to find what broke this build.

Trying to create a min. reproducer out of this package also does not produce this bug correctly.

The best compromise here is to just change the url. Since a min. reproducer could not be created, a fastn bug is not filed at the time of writing this commit.